### PR TITLE
fix: add missing from and to query parameter in schema

### DIFF
--- a/api/openapi-spec/openapi.json
+++ b/api/openapi-spec/openapi.json
@@ -189,6 +189,28 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "required": false,
+            "description": "Select air quality observations from time. Must be used together with `to`.",
+            "example": "2021-06-01T00:00:00Z",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "required": false,
+            "description": "Select air quality observations up to time. Must be used together with `from`.",
+            "example": "2021-07-01T00:00:00Z",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           }
         ],
         "responses": {


### PR DESCRIPTION
The handler implementation supports time range filtering but the OpenAPI
schema was missing the query parameter definitions. Added from and
to.