### PR TITLE
feat: add pagination support for air quality temporal queries

### DIFF
--- a/api/openapi-spec/openapi.json
+++ b/api/openapi-spec/openapi.json
@@ -167,6 +167,24 @@
                           }
                         }
                       }
+                    },
+                    "links": {
+                      "type": "object",
+                      "description": "Pagination links for retrieving additional temporal data when results are partial.",
+                      "properties": {
+                        "self": {
+                          "type": "string",
+                          "format": "uri",
+                          "description": "URL of the current request.",
+                          "example": "/airqualities/urn:ngsi-ld:AirQualityObserved:test3?from=2025-02-12T00:00:00Z&to=2025-02-13T00:00:00Z"
+                        },
+                        "next": {
+                          "type": "string",
+                          "format": "uri",
+                          "description": "URL to retrieve the next set of temporal data. Only present when there is more data available.",
+                          "example": "/airqualities/urn:ngsi-ld:AirQualityObserved:test3?from=2025-02-13T00:00:00Z&to=2025-02-14T00:00:00Z"
+                        }
+                      }
                     }
                   }
                 }
@@ -188,6 +206,28 @@
             "description": "Unique identifier of the air quality observation.",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "required": false,
+            "description": "Select air quality observations from time. Must be used together with `to`.",
+            "example": "2021-06-01T00:00:00Z",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "required": false,
+            "description": "Select air quality observations up to time. Must be used together with `from`.",
+            "example": "2021-07-01T00:00:00Z",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
             }
           }
         ],

--- a/api/openapi-spec/openapi.json
+++ b/api/openapi-spec/openapi.json
@@ -167,24 +167,6 @@
                           }
                         }
                       }
-                    },
-                    "links": {
-                      "type": "object",
-                      "description": "Pagination links for retrieving additional temporal data when results are partial.",
-                      "properties": {
-                        "self": {
-                          "type": "string",
-                          "format": "uri",
-                          "description": "URL of the current request.",
-                          "example": "/airqualities/urn:ngsi-ld:AirQualityObserved:test3?from=2025-02-12T00:00:00Z&to=2025-02-13T00:00:00Z"
-                        },
-                        "next": {
-                          "type": "string",
-                          "format": "uri",
-                          "description": "URL to retrieve the next set of temporal data. Only present when there is more data available.",
-                          "example": "/airqualities/urn:ngsi-ld:AirQualityObserved:test3?from=2025-02-13T00:00:00Z&to=2025-02-14T00:00:00Z"
-                        }
-                      }
                     }
                   }
                 }
@@ -212,7 +194,8 @@
             "name": "from",
             "in": "query",
             "required": false,
-            "description": "Select air quality observations from time. Must be used together with `to`.",
+            "deprecated": true,
+            "description": "**Deprecated:** Use `timeAt` instead. Select air quality observations from time. Must be used together with `to`.",
             "example": "2021-06-01T00:00:00Z",
             "schema": {
               "type": "string",
@@ -223,7 +206,30 @@
             "name": "to",
             "in": "query",
             "required": false,
-            "description": "Select air quality observations up to time. Must be used together with `from`.",
+            "deprecated": true,
+            "description": "**Deprecated:** Use `endTimeAt` instead. Select air quality observations up to time. Must be used together with `from`.",
+            "example": "2021-07-01T00:00:00Z",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "timeAt",
+            "in": "query",
+            "required": false,
+            "description": "Select air quality observations from time. Must be used together with `endTimeAt`.",
+            "example": "2021-06-01T00:00:00Z",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "endTimeAt",
+            "in": "query",
+            "required": false,
+            "description": "Select air quality observations up to time. Must be used together with `timeAt`.",
             "example": "2021-07-01T00:00:00Z",
             "schema": {
               "type": "string",
@@ -304,6 +310,24 @@
                               }
                             }
                           }
+                        }
+                      }
+                    },
+                    "links": {
+                      "type": "object",
+                      "description": "Pagination links for retrieving additional temporal data when results are partial.",
+                      "properties": {
+                        "self": {
+                          "type": "string",
+                          "format": "uri",
+                          "description": "URL of the current request.",
+                          "example": "/airqualities/urn:ngsi-ld:AirQualityObserved:test3?timeAt=2025-01-13T00:00:00Z&endTimeAt=2025-04-20T00:00:00Z"
+                        },
+                        "next": {
+                          "type": "string",
+                          "format": "uri",
+                          "description": "URL to retrieve the next set of temporal data. Only present when there is more data available.",
+                          "example": "/airqualities/urn:ngsi-ld:AirQualityObserved:test3?timeAt=2025-02-13T00:00:00Z&endTimeAt=2025-04-14T00:00:00Z"
                         }
                       }
                     }

--- a/internal/pkg/application/services/airquality/airqualitysvc.go
+++ b/internal/pkg/application/services/airquality/airqualitysvc.go
@@ -38,7 +38,7 @@ type AirQualityService interface {
 
 	GetAll(ctx context.Context) []domain.AirQuality
 	GetByID(ctx context.Context, id string) (*domain.AirQualityDetails, error)
-	GetByIDWithTimespan(ctx context.Context, id string, from, to time.Time) (*domain.AirQualityDetails, *NextTimespan, error)
+	GetByIDWithTimespan(ctx context.Context, id string, from, to time.Time) (*domain.AirQualityDetails, *Timespan, error)
 }
 
 var ErrNoSuchAirQuality error = errors.New("no such air quality")
@@ -108,12 +108,12 @@ func (svc *aqsvc) GetByID(ctx context.Context, id string) (*domain.AirQualityDet
 	}
 }
 
-type NextTimespan struct {
-	From *time.Time
-	To   *time.Time
+type Timespan struct {
+	From time.Time
+	To   time.Time
 }
 
-func (svc *aqsvc) GetByIDWithTimespan(ctx context.Context, id string, from, to time.Time) (*domain.AirQualityDetails, *NextTimespan, error) {
+func (svc *aqsvc) GetByIDWithTimespan(ctx context.Context, id string, from, to time.Time) (*domain.AirQualityDetails, *Timespan, error) {
 	logger := logging.GetFromContext(ctx)
 
 	headers := map[string][]string{
@@ -127,28 +127,25 @@ func (svc *aqsvc) GetByIDWithTimespan(ctx context.Context, id string, from, to t
 
 	pollutantMap := make(map[string]*domain.Pollutant)
 
-	var t *ngsild.RetrieveTemporalEvolutionOfEntityResult
-	var err error
+	var timeSpan *Timespan = &Timespan{From: from, To: to}
 
-	var requestLimit = 3
-	var nextTimespan2 *NextTimespan = &NextTimespan{From: &from, To: &to}
+	for range 3 {
 
-	for range requestLimit {
-
-		t, err = svc.cbClient.RetrieveTemporalEvolutionOfEntity(ctx, id, headers, client.Between(*nextTimespan2.From, *nextTimespan2.To))
+		t, err := svc.cbClient.RetrieveTemporalEvolutionOfEntity(ctx, id, headers, client.Between(timeSpan.From, timeSpan.To))
 		if err != nil || t.Found == nil {
-			logger.Error(fmt.Sprintf("failed to retrieve temporal evolution of air quality with id %s and within timespan %s-%s", id, nextTimespan2.From.Format(time.RFC3339), nextTimespan2.To.Format(time.RFC3339)), "err", err.Error())
+			logger.Error(fmt.Sprintf("failed to retrieve temporal evolution of air quality with id %s and within timespan %s-%s", id, timeSpan.From.Format(time.RFC3339), timeSpan.To.Format(time.RFC3339)), "err", err.Error())
 			return nil, nil, err
 		}
 
 		mergePollutants(pollutantMap, getPollutantsFromFoundProperties(t))
 
 		if !t.PartialResult {
-			nextTimespan2 = nil
+			timeSpan = nil
 			break
 		}
 
-		nextTimespan2 = &NextTimespan{From: t.ContentRange.EndTime, To: &to}
+		timeSpan.From = *t.ContentRange.EndTime
+		timeSpan.To = to
 	}
 
 	// Convert map to slice
@@ -156,7 +153,7 @@ func (svc *aqsvc) GetByIDWithTimespan(ctx context.Context, id string, from, to t
 		aq.Pollutants = append(aq.Pollutants, *p)
 	}
 
-	return aq, nextTimespan2, nil
+	return aq, timeSpan, nil
 }
 
 func mergePollutants(pollutantMap map[string]*domain.Pollutant, newPollutants []domain.Pollutant) {

--- a/internal/pkg/application/services/airquality/airqualitysvc.go
+++ b/internal/pkg/application/services/airquality/airqualitysvc.go
@@ -38,7 +38,7 @@ type AirQualityService interface {
 
 	GetAll(ctx context.Context) []domain.AirQuality
 	GetByID(ctx context.Context, id string) (*domain.AirQualityDetails, error)
-	GetByIDWithTimespan(ctx context.Context, id string, from, to time.Time) (*domain.AirQualityDetails, error)
+	GetByIDWithTimespan(ctx context.Context, id string, from, to time.Time) (*domain.AirQualityDetails, *NextTimespan, error)
 }
 
 var ErrNoSuchAirQuality error = errors.New("no such air quality")
@@ -108,7 +108,12 @@ func (svc *aqsvc) GetByID(ctx context.Context, id string) (*domain.AirQualityDet
 	}
 }
 
-func (svc *aqsvc) GetByIDWithTimespan(ctx context.Context, id string, from, to time.Time) (*domain.AirQualityDetails, error) {
+type NextTimespan struct {
+	From *time.Time
+	To   *time.Time
+}
+
+func (svc *aqsvc) GetByIDWithTimespan(ctx context.Context, id string, from, to time.Time) (*domain.AirQualityDetails, *NextTimespan, error) {
 	logger := logging.GetFromContext(ctx)
 
 	headers := map[string][]string{
@@ -120,15 +125,49 @@ func (svc *aqsvc) GetByIDWithTimespan(ctx context.Context, id string, from, to t
 	aq.ID = id
 	aq.Location = svc.airQualityByID[id].Location
 
-	t, err := svc.cbClient.RetrieveTemporalEvolutionOfEntity(ctx, id, headers, client.Between(from, to))
-	if err != nil || t.Found == nil {
-		logger.Error(fmt.Sprintf("failed to retrieve temporal evolution of air quality with id %s and within timespan %s-%s", id, from.Format(time.RFC3339), to.Format(time.RFC3339)), "err", err.Error())
-		return nil, err
+	pollutantMap := make(map[string]*domain.Pollutant)
+
+	var t *ngsild.RetrieveTemporalEvolutionOfEntityResult
+	var err error
+
+	var requestLimit = 3
+	var nextTimespan2 *NextTimespan = &NextTimespan{From: &from, To: &to}
+
+	for range requestLimit {
+
+		t, err = svc.cbClient.RetrieveTemporalEvolutionOfEntity(ctx, id, headers, client.Between(*nextTimespan2.From, *nextTimespan2.To))
+		if err != nil || t.Found == nil {
+			logger.Error(fmt.Sprintf("failed to retrieve temporal evolution of air quality with id %s and within timespan %s-%s", id, nextTimespan2.From.Format(time.RFC3339), nextTimespan2.To.Format(time.RFC3339)), "err", err.Error())
+			return nil, nil, err
+		}
+
+		mergePollutants(pollutantMap, getPollutantsFromFoundProperties(t))
+
+		if !t.PartialResult {
+			nextTimespan2 = nil
+			break
+		}
+
+		nextTimespan2 = &NextTimespan{From: t.ContentRange.EndTime, To: &to}
 	}
 
-	aq.Pollutants = getPollutantsFromFoundProperties(t)
+	// Convert map to slice
+	for _, p := range pollutantMap {
+		aq.Pollutants = append(aq.Pollutants, *p)
+	}
 
-	return aq, nil
+	return aq, nextTimespan2, nil
+}
+
+func mergePollutants(pollutantMap map[string]*domain.Pollutant, newPollutants []domain.Pollutant) {
+	for _, p := range newPollutants {
+		if existing, ok := pollutantMap[p.Name]; ok {
+			existing.Values = append(existing.Values, p.Values...)
+		} else {
+			cp := p
+			pollutantMap[p.Name] = &cp
+		}
+	}
 }
 
 func (svc *aqsvc) Refresh(ctx context.Context) (int, error) {

--- a/internal/pkg/application/services/airquality/airqualitysvc.go
+++ b/internal/pkg/application/services/airquality/airqualitysvc.go
@@ -38,7 +38,7 @@ type AirQualityService interface {
 
 	GetAll(ctx context.Context) []domain.AirQuality
 	GetByID(ctx context.Context, id string) (*domain.AirQualityDetails, error)
-	GetByIDWithTimespan(ctx context.Context, id string, from, to time.Time) (*domain.AirQualityDetails, *Timespan, error)
+	GetByIDWithTimespan(ctx context.Context, id string, timeAt, endTimeAt time.Time) (*domain.AirQualityDetails, *Timespan, error)
 }
 
 var ErrNoSuchAirQuality error = errors.New("no such air quality")
@@ -113,7 +113,7 @@ type Timespan struct {
 	To   time.Time
 }
 
-func (svc *aqsvc) GetByIDWithTimespan(ctx context.Context, id string, from, to time.Time) (*domain.AirQualityDetails, *Timespan, error) {
+func (svc *aqsvc) GetByIDWithTimespan(ctx context.Context, id string, timeAt, endTimeAt time.Time) (*domain.AirQualityDetails, *Timespan, error) {
 	logger := logging.GetFromContext(ctx)
 
 	headers := map[string][]string{
@@ -127,10 +127,9 @@ func (svc *aqsvc) GetByIDWithTimespan(ctx context.Context, id string, from, to t
 
 	pollutantMap := make(map[string]*domain.Pollutant)
 
-	var timeSpan *Timespan = &Timespan{From: from, To: to}
+	var timeSpan *Timespan = &Timespan{From: timeAt, To: endTimeAt}
 
-	for range 3 {
-
+	for range 3 { // Limit to 3 iterations per page, which is a reasonable payload size with max 300 datapoints per pollutant.
 		t, err := svc.cbClient.RetrieveTemporalEvolutionOfEntity(ctx, id, headers, client.Between(timeSpan.From, timeSpan.To))
 		if err != nil || t.Found == nil {
 			logger.Error(fmt.Sprintf("failed to retrieve temporal evolution of air quality with id %s and within timespan %s-%s", id, timeSpan.From.Format(time.RFC3339), timeSpan.To.Format(time.RFC3339)), "err", err.Error())
@@ -145,7 +144,7 @@ func (svc *aqsvc) GetByIDWithTimespan(ctx context.Context, id string, from, to t
 		}
 
 		timeSpan.From = *t.ContentRange.EndTime
-		timeSpan.To = to
+		timeSpan.To = endTimeAt
 	}
 
 	// Convert map to slice

--- a/internal/pkg/application/services/airquality/airqualitysvc.go
+++ b/internal/pkg/application/services/airquality/airqualitysvc.go
@@ -131,8 +131,13 @@ func (svc *aqsvc) GetByIDWithTimespan(ctx context.Context, id string, timeAt, en
 
 	for range 3 { // Limit to 3 iterations per page, which is a reasonable payload size with max 300 datapoints per pollutant.
 		t, err := svc.cbClient.RetrieveTemporalEvolutionOfEntity(ctx, id, headers, client.Between(timeSpan.From, timeSpan.To))
+
 		if err != nil || t.Found == nil {
-			logger.Error(fmt.Sprintf("failed to retrieve temporal evolution of air quality with id %s and within timespan %s-%s", id, timeSpan.From.Format(time.RFC3339), timeSpan.To.Format(time.RFC3339)), "err", err.Error())
+			errMsg := ""
+			if err != nil {
+				errMsg = err.Error()
+			}
+			logger.Error(fmt.Sprintf("failed to retrieve temporal evolution of air quality with id %s and within timespan %s-%s", id, timeSpan.From.Format(time.RFC3339), timeSpan.To.Format(time.RFC3339)), "err", errMsg)
 			return nil, nil, err
 		}
 

--- a/internal/pkg/application/services/airquality/airqualitysvc_mock.go
+++ b/internal/pkg/application/services/airquality/airqualitysvc_mock.go
@@ -56,7 +56,7 @@ type AirQualityServiceMock struct {
 	GetByIDFunc func(ctx context.Context, id string) (*domain.AirQualityDetails, error)
 
 	// GetByIDWithTimespanFunc mocks the GetByIDWithTimespan method.
-	GetByIDWithTimespanFunc func(ctx context.Context, id string, from time.Time, to time.Time) (*domain.AirQualityDetails, *NextTimespan, error)
+	GetByIDWithTimespanFunc func(ctx context.Context, id string, from time.Time, to time.Time) (*domain.AirQualityDetails, *Timespan, error)
 
 	// RefreshFunc mocks the Refresh method.
 	RefreshFunc func(ctx context.Context) (int, error)
@@ -192,7 +192,7 @@ func (mock *AirQualityServiceMock) GetByIDCalls() []struct {
 }
 
 // GetByIDWithTimespan calls GetByIDWithTimespanFunc.
-func (mock *AirQualityServiceMock) GetByIDWithTimespan(ctx context.Context, id string, from time.Time, to time.Time) (*domain.AirQualityDetails, *NextTimespan, error) {
+func (mock *AirQualityServiceMock) GetByIDWithTimespan(ctx context.Context, id string, from time.Time, to time.Time) (*domain.AirQualityDetails, *Timespan, error) {
 	if mock.GetByIDWithTimespanFunc == nil {
 		panic("AirQualityServiceMock.GetByIDWithTimespanFunc: method is nil but AirQualityService.GetByIDWithTimespan was just called")
 	}

--- a/internal/pkg/application/services/airquality/airqualitysvc_mock.go
+++ b/internal/pkg/application/services/airquality/airqualitysvc_mock.go
@@ -5,9 +5,10 @@ package airquality
 
 import (
 	"context"
-	"github.com/diwise/api-opendata/internal/pkg/domain"
 	"sync"
 	"time"
+
+	"github.com/diwise/api-opendata/internal/pkg/domain"
 )
 
 // Ensure, that AirQualityServiceMock does implement AirQualityService.
@@ -16,37 +17,37 @@ var _ AirQualityService = &AirQualityServiceMock{}
 
 // AirQualityServiceMock is a mock implementation of AirQualityService.
 //
-// 	func TestSomethingThatUsesAirQualityService(t *testing.T) {
+//	func TestSomethingThatUsesAirQualityService(t *testing.T) {
 //
-// 		// make and configure a mocked AirQualityService
-// 		mockedAirQualityService := &AirQualityServiceMock{
-// 			GetAllFunc: func(ctx context.Context) []domain.AirQuality {
-// 				panic("mock out the GetAll method")
-// 			},
-// 			GetByIDFunc: func(ctx context.Context, id string) (*domain.AirQualityDetails, error) {
-// 				panic("mock out the GetByID method")
-// 			},
-// 			GetByIDWithTimespanFunc: func(ctx context.Context, id string, from time.Time, to time.Time) (*domain.AirQualityDetails, error) {
-// 				panic("mock out the GetByIDWithTimespan method")
-// 			},
-// 			RefreshFunc: func(ctx context.Context) (int, error) {
-// 				panic("mock out the Refresh method")
-// 			},
-// 			ShutdownFunc: func(ctx context.Context)  {
-// 				panic("mock out the Shutdown method")
-// 			},
-// 			StartFunc: func(ctx context.Context)  {
-// 				panic("mock out the Start method")
-// 			},
-// 			TenantFunc: func() string {
-// 				panic("mock out the Tenant method")
-// 			},
-// 		}
+//		// make and configure a mocked AirQualityService
+//		mockedAirQualityService := &AirQualityServiceMock{
+//			GetAllFunc: func(ctx context.Context) []domain.AirQuality {
+//				panic("mock out the GetAll method")
+//			},
+//			GetByIDFunc: func(ctx context.Context, id string) (*domain.AirQualityDetails, error) {
+//				panic("mock out the GetByID method")
+//			},
+//			GetByIDWithTimespanFunc: func(ctx context.Context, id string, from time.Time, to time.Time) (*domain.AirQualityDetails, error) {
+//				panic("mock out the GetByIDWithTimespan method")
+//			},
+//			RefreshFunc: func(ctx context.Context) (int, error) {
+//				panic("mock out the Refresh method")
+//			},
+//			ShutdownFunc: func(ctx context.Context)  {
+//				panic("mock out the Shutdown method")
+//			},
+//			StartFunc: func(ctx context.Context)  {
+//				panic("mock out the Start method")
+//			},
+//			TenantFunc: func() string {
+//				panic("mock out the Tenant method")
+//			},
+//		}
 //
-// 		// use mockedAirQualityService in code that requires AirQualityService
-// 		// and then make assertions.
+//		// use mockedAirQualityService in code that requires AirQualityService
+//		// and then make assertions.
 //
-// 	}
+//	}
 type AirQualityServiceMock struct {
 	// GetAllFunc mocks the GetAll method.
 	GetAllFunc func(ctx context.Context) []domain.AirQuality
@@ -55,7 +56,7 @@ type AirQualityServiceMock struct {
 	GetByIDFunc func(ctx context.Context, id string) (*domain.AirQualityDetails, error)
 
 	// GetByIDWithTimespanFunc mocks the GetByIDWithTimespan method.
-	GetByIDWithTimespanFunc func(ctx context.Context, id string, from time.Time, to time.Time) (*domain.AirQualityDetails, error)
+	GetByIDWithTimespanFunc func(ctx context.Context, id string, from time.Time, to time.Time) (*domain.AirQualityDetails, *NextTimespan, error)
 
 	// RefreshFunc mocks the Refresh method.
 	RefreshFunc func(ctx context.Context) (int, error)
@@ -140,7 +141,8 @@ func (mock *AirQualityServiceMock) GetAll(ctx context.Context) []domain.AirQuali
 
 // GetAllCalls gets all the calls that were made to GetAll.
 // Check the length with:
-//     len(mockedAirQualityService.GetAllCalls())
+//
+//	len(mockedAirQualityService.GetAllCalls())
 func (mock *AirQualityServiceMock) GetAllCalls() []struct {
 	Ctx context.Context
 } {
@@ -173,7 +175,8 @@ func (mock *AirQualityServiceMock) GetByID(ctx context.Context, id string) (*dom
 
 // GetByIDCalls gets all the calls that were made to GetByID.
 // Check the length with:
-//     len(mockedAirQualityService.GetByIDCalls())
+//
+//	len(mockedAirQualityService.GetByIDCalls())
 func (mock *AirQualityServiceMock) GetByIDCalls() []struct {
 	Ctx context.Context
 	ID  string
@@ -189,7 +192,7 @@ func (mock *AirQualityServiceMock) GetByIDCalls() []struct {
 }
 
 // GetByIDWithTimespan calls GetByIDWithTimespanFunc.
-func (mock *AirQualityServiceMock) GetByIDWithTimespan(ctx context.Context, id string, from time.Time, to time.Time) (*domain.AirQualityDetails, error) {
+func (mock *AirQualityServiceMock) GetByIDWithTimespan(ctx context.Context, id string, from time.Time, to time.Time) (*domain.AirQualityDetails, *NextTimespan, error) {
 	if mock.GetByIDWithTimespanFunc == nil {
 		panic("AirQualityServiceMock.GetByIDWithTimespanFunc: method is nil but AirQualityService.GetByIDWithTimespan was just called")
 	}
@@ -212,7 +215,8 @@ func (mock *AirQualityServiceMock) GetByIDWithTimespan(ctx context.Context, id s
 
 // GetByIDWithTimespanCalls gets all the calls that were made to GetByIDWithTimespan.
 // Check the length with:
-//     len(mockedAirQualityService.GetByIDWithTimespanCalls())
+//
+//	len(mockedAirQualityService.GetByIDWithTimespanCalls())
 func (mock *AirQualityServiceMock) GetByIDWithTimespanCalls() []struct {
 	Ctx  context.Context
 	ID   string
@@ -249,7 +253,8 @@ func (mock *AirQualityServiceMock) Refresh(ctx context.Context) (int, error) {
 
 // RefreshCalls gets all the calls that were made to Refresh.
 // Check the length with:
-//     len(mockedAirQualityService.RefreshCalls())
+//
+//	len(mockedAirQualityService.RefreshCalls())
 func (mock *AirQualityServiceMock) RefreshCalls() []struct {
 	Ctx context.Context
 } {
@@ -280,7 +285,8 @@ func (mock *AirQualityServiceMock) Shutdown(ctx context.Context) {
 
 // ShutdownCalls gets all the calls that were made to Shutdown.
 // Check the length with:
-//     len(mockedAirQualityService.ShutdownCalls())
+//
+//	len(mockedAirQualityService.ShutdownCalls())
 func (mock *AirQualityServiceMock) ShutdownCalls() []struct {
 	Ctx context.Context
 } {
@@ -311,7 +317,8 @@ func (mock *AirQualityServiceMock) Start(ctx context.Context) {
 
 // StartCalls gets all the calls that were made to Start.
 // Check the length with:
-//     len(mockedAirQualityService.StartCalls())
+//
+//	len(mockedAirQualityService.StartCalls())
 func (mock *AirQualityServiceMock) StartCalls() []struct {
 	Ctx context.Context
 } {
@@ -339,7 +346,8 @@ func (mock *AirQualityServiceMock) Tenant() string {
 
 // TenantCalls gets all the calls that were made to Tenant.
 // Check the length with:
-//     len(mockedAirQualityService.TenantCalls())
+//
+//	len(mockedAirQualityService.TenantCalls())
 func (mock *AirQualityServiceMock) TenantCalls() []struct {
 } {
 	var calls []struct {

--- a/internal/pkg/domain/models.go
+++ b/internal/pkg/domain/models.go
@@ -4,6 +4,17 @@ import (
 	"time"
 )
 
+type JSONAPIResponse struct {
+	Data  any          `json:"data"`
+	Links JSONAPILinks `json:"links,omitempty"`
+}
+
+type JSONAPILinks struct {
+	Next string `json:"next,omitempty"`
+	Prev string `json:"prev,omitempty"`
+	Self string `json:"self,omitempty"`
+}
+
 // Catalog ..
 type Catalog struct {
 	About       string

--- a/internal/pkg/presentation/handlers/airquality.go
+++ b/internal/pkg/presentation/handlers/airquality.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/diwise/api-opendata/internal/pkg/application/services/airquality"
 	"github.com/diwise/api-opendata/internal/pkg/domain"
+	"github.com/diwise/api-opendata/internal/pkg/presentation/handlers/webutil"
 	"github.com/diwise/service-chassis/pkg/infrastructure/o11y"
 	"github.com/diwise/service-chassis/pkg/infrastructure/o11y/logging"
 	"github.com/diwise/service-chassis/pkg/infrastructure/o11y/tracing"
@@ -97,6 +98,7 @@ func NewRetrieveAirQualityByIDHandler(ctx context.Context, aqsvc airquality.AirQ
 		}
 
 		aq := &domain.AirQualityDetails{}
+		next := &airquality.NextTimespan{}
 
 		from, to, err := getTimeParametersFromQuery(r)
 		if err != nil {
@@ -109,20 +111,47 @@ func NewRetrieveAirQualityByIDHandler(ctx context.Context, aqsvc airquality.AirQ
 				return
 			}
 		} else {
-			aq, err = aqsvc.GetByIDWithTimespan(ctx, airQualityID, from, to)
+			aq, next, err = aqsvc.GetByIDWithTimespan(ctx, airQualityID, from, to)
 			if err != nil {
 				w.WriteHeader(http.StatusNotFound)
 				return
 			}
 		}
 
-		bodyBytes, _ := json.Marshal(aq)
+		u := webutil.BuildPublicURL(r)
+		u.RawQuery = r.URL.Query().Encode()
+		selfLink := u.String()
 
-		body := []byte("{\"data\": " + string(bodyBytes) + "}")
+		links := domain.JSONAPILinks{
+			Self: selfLink,
+		}
+		if next != nil && next.From != nil && next.To != nil {
+			nu, _ := url.Parse(selfLink)
+			nq := nu.Query()
+			nq.Set("from", next.From.Format(time.RFC3339))
+			nq.Set("to", next.To.Format(time.RFC3339))
+			nu.RawQuery = nq.Encode()
+			nextLink := nu.String()
+			links.Next = nextLink
+		}
 
+		dataBytes, _ := json.Marshal(aq)
+		var linksBuffer bytes.Buffer
+		linksEnc := json.NewEncoder(&linksBuffer)
+		linksEnc.SetEscapeHTML(false)
+		_ = linksEnc.Encode(links)
+		linksBytes := bytes.TrimRight(linksBuffer.Bytes(), "\n")
+
+		responseBytes := make([]byte, 0, len(dataBytes)+len(linksBytes)+20)
+		responseBuffer := bytes.NewBuffer(responseBytes)
+		responseBuffer.WriteString("{\"data\":")
+		responseBuffer.Write(dataBytes)
+		responseBuffer.WriteString(",\"links\":")
+		responseBuffer.Write(linksBytes)
+		responseBuffer.WriteString("}")
 		w.Header().Add("Content-Type", "application/json")
 		w.Header().Add("Cache-Control", "max-age=600")
-		w.Write(body)
+		w.Write(responseBuffer.Bytes())
 	})
 }
 

--- a/internal/pkg/presentation/handlers/airquality.go
+++ b/internal/pkg/presentation/handlers/airquality.go
@@ -97,21 +97,23 @@ func NewRetrieveAirQualityByIDHandler(ctx context.Context, aqsvc airquality.AirQ
 			return
 		}
 
-		aq := &domain.AirQualityDetails{}
-		next := &airquality.Timespan{}
+		var aq *domain.AirQualityDetails
+		var next *airquality.Timespan
 
-		from, to, err := getTimeParametersFromQuery(r)
+		timeAt, endTimeAt, hasTimeSpan, err := resolveTimeSpanFromQuery(r)
 		if err != nil {
+			problem := errors.NewProblemReport(http.StatusBadRequest, "badrequest", errors.Detail(err.Error()), errors.TraceID(traceID))
+			problem.WriteResponse(w)
 			return
 		}
-		if from.IsZero() && to.IsZero() {
+		if !hasTimeSpan {
 			aq, err = aqsvc.GetByID(ctx, airQualityID)
 			if err != nil {
 				w.WriteHeader(http.StatusNotFound)
 				return
 			}
 		} else {
-			aq, next, err = aqsvc.GetByIDWithTimespan(ctx, airQualityID, from, to)
+			aq, next, err = aqsvc.GetByIDWithTimespan(ctx, airQualityID, timeAt, endTimeAt)
 			if err != nil {
 				w.WriteHeader(http.StatusNotFound)
 				return
@@ -128,8 +130,11 @@ func NewRetrieveAirQualityByIDHandler(ctx context.Context, aqsvc airquality.AirQ
 		if next != nil {
 			nu, _ := url.Parse(selfLink)
 			nq := nu.Query()
-			nq.Set("from", next.From.Format(time.RFC3339))
-			nq.Set("to", next.To.Format(time.RFC3339))
+			// Remove legacy params if present
+			nq.Del("from")
+			nq.Del("to")
+			nq.Set("timeAt", next.From.Format(time.RFC3339))
+			nq.Set("endTimeAt", next.To.Format(time.RFC3339))
 			nu.RawQuery = nq.Encode()
 			nextLink := nu.String()
 			links.Next = nextLink
@@ -155,7 +160,44 @@ func NewRetrieveAirQualityByIDHandler(ctx context.Context, aqsvc airquality.AirQ
 	})
 }
 
-func getTimeParametersFromQuery(r *http.Request) (from, to time.Time, err error) {
+func resolveTimeSpanFromQuery(r *http.Request) (timeAt, endTimeAt time.Time, hasTimeSpan bool, err error) {
+
+	timeAt, endTimeAt, err = get_TimeAt_EndTimeAt_FromQuery(r)
+	if err != nil {
+		return
+	}
+
+	from, to, err := get_From_To_ParametersFromQuery(r)
+	if err != nil {
+		return
+	}
+
+	// Check for conflicting parameter sets
+	hasNewParams := !timeAt.IsZero() && !endTimeAt.IsZero()
+	hasLegacyParams := !from.IsZero() && !to.IsZero()
+
+	if hasNewParams && hasLegacyParams {
+		err = fmt.Errorf("cannot use both from/to and timeAt/endTimeAt parameters at the same time.")
+		return
+	}
+
+	// Use legacy params if new ones not provided
+	if !hasNewParams && hasLegacyParams {
+		timeAt = from
+		endTimeAt = to
+	}
+
+	// Validate time ordering
+	if !timeAt.IsZero() && !endTimeAt.IsZero() && endTimeAt.Before(timeAt) {
+		err = fmt.Errorf("endTimeAt time cannot be before timeAt")
+		return
+	}
+
+	hasTimeSpan = !timeAt.IsZero() && !endTimeAt.IsZero()
+	return
+}
+
+func get_From_To_ParametersFromQuery(r *http.Request) (from, to time.Time, err error) {
 	f := r.URL.Query().Get("from")
 	if f == "" {
 		return from, to, err
@@ -177,6 +219,30 @@ func getTimeParametersFromQuery(r *http.Request) (from, to time.Time, err error)
 	}
 
 	return from, to, nil
+}
+
+func get_TimeAt_EndTimeAt_FromQuery(r *http.Request) (timeAt, endTimeAt time.Time, err error) {
+	ta := r.URL.Query().Get("timeAt")
+	if ta == "" {
+		return timeAt, endTimeAt, err
+	}
+
+	timeAt, err = time.Parse(time.RFC3339, ta)
+	if err != nil {
+		return timeAt, endTimeAt, fmt.Errorf("could not parse a valid time from \"timeAt\" parameter: %s", err.Error())
+	}
+
+	eta := r.URL.Query().Get("endTimeAt")
+	if eta == "" {
+		return timeAt, endTimeAt, err
+	}
+
+	endTimeAt, err = time.Parse(time.RFC3339, eta)
+	if err != nil {
+		return timeAt, endTimeAt, fmt.Errorf("could not parse a valid time from \"endTimeAt\" parameter: %s", err.Error())
+	}
+
+	return timeAt, endTimeAt, nil
 }
 
 type AirQualityMapperFunc func(*domain.AirQuality) ([]byte, error)

--- a/internal/pkg/presentation/handlers/airquality.go
+++ b/internal/pkg/presentation/handlers/airquality.go
@@ -97,15 +97,16 @@ func NewRetrieveAirQualityByIDHandler(ctx context.Context, aqsvc airquality.AirQ
 			return
 		}
 
-		var aq *domain.AirQualityDetails
-		var next *airquality.Timespan
-
 		timeAt, endTimeAt, hasTimeSpan, err := resolveTimeSpanFromQuery(r)
 		if err != nil {
 			problem := errors.NewProblemReport(http.StatusBadRequest, "badrequest", errors.Detail(err.Error()), errors.TraceID(traceID))
 			problem.WriteResponse(w)
 			return
 		}
+
+		var aq *domain.AirQualityDetails
+		var next *airquality.Timespan
+
 		if !hasTimeSpan {
 			aq, err = aqsvc.GetByID(ctx, airQualityID)
 			if err != nil {
@@ -200,7 +201,7 @@ func resolveTimeSpanFromQuery(r *http.Request) (timeAt, endTimeAt time.Time, has
 func get_From_To_ParametersFromQuery(r *http.Request) (from, to time.Time, err error) {
 	f := r.URL.Query().Get("from")
 	if f == "" {
-		return from, to, err
+		return
 	}
 
 	from, err = time.Parse(time.RFC3339, f)
@@ -224,7 +225,7 @@ func get_From_To_ParametersFromQuery(r *http.Request) (from, to time.Time, err e
 func get_TimeAt_EndTimeAt_FromQuery(r *http.Request) (timeAt, endTimeAt time.Time, err error) {
 	ta := r.URL.Query().Get("timeAt")
 	if ta == "" {
-		return timeAt, endTimeAt, err
+		return
 	}
 
 	timeAt, err = time.Parse(time.RFC3339, ta)

--- a/internal/pkg/presentation/handlers/airquality.go
+++ b/internal/pkg/presentation/handlers/airquality.go
@@ -98,7 +98,7 @@ func NewRetrieveAirQualityByIDHandler(ctx context.Context, aqsvc airquality.AirQ
 		}
 
 		aq := &domain.AirQualityDetails{}
-		next := &airquality.NextTimespan{}
+		next := &airquality.Timespan{}
 
 		from, to, err := getTimeParametersFromQuery(r)
 		if err != nil {
@@ -125,7 +125,7 @@ func NewRetrieveAirQualityByIDHandler(ctx context.Context, aqsvc airquality.AirQ
 		links := domain.JSONAPILinks{
 			Self: selfLink,
 		}
-		if next != nil && next.From != nil && next.To != nil {
+		if next != nil {
 			nu, _ := url.Parse(selfLink)
 			nq := nu.Query()
 			nq.Set("from", next.From.Format(time.RFC3339))

--- a/internal/pkg/presentation/handlers/airquality_test.go
+++ b/internal/pkg/presentation/handlers/airquality_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"regexp"
 	"testing"
 	"time"
 
@@ -36,7 +37,9 @@ func TestRetrieveAirQualityByID(t *testing.T) {
 	is.Equal(response.StatusCode, http.StatusOK)
 	is.Equal(len(svc.GetByIDCalls()), 1)
 
-	is.Equal(responseBody, expectedAirQualityByIDOutput)
+	re := regexp.MustCompile(`https?://[^/]+`)
+	cleanedBody := re.ReplaceAllString(responseBody, "")
+	is.Equal(cleanedBody, expectedAirQualityByIDOutput)
 }
 
 func TestRetrieveAirQualityByIDParsesTimeParamsCorrectly(t *testing.T) {
@@ -50,7 +53,24 @@ func TestRetrieveAirQualityByIDParsesTimeParamsCorrectly(t *testing.T) {
 	is.Equal(len(svc.GetByIDWithTimespanCalls()), 1)
 }
 
-const expectedAirQualityByIDOutput string = `{"data": {"id":"aq1","location":{"type":"Point","coordinates":[17.1,62.1]},"dateObserved":{"@type":"DateTime","@value":"2022-10-21T13:10:00Z"},"pollutants":[{"name":"Temperature","values":[{"value":12.6,"observedAt":"2022-10-20T13:10:00Z"}]}]}}`
+func TestRetrieveAirQualityByIDCorrectLinks(t *testing.T) {
+	is, r, ts := setupTest(t)
+	svc := defaultAirQualityMock()
+
+	r.Get("/{id}", NewRetrieveAirQualityByIDHandler(context.Background(), svc))
+	response, responseBody := newGetRequest(is, ts, "application/ld+json", "/aq1?from=2022-10-19T13:10:00Z&to=2022-10-22T13:10:00Z", nil)
+
+	is.Equal(response.StatusCode, http.StatusOK)
+	is.Equal(len(svc.GetByIDWithTimespanCalls()), 1)
+
+	re := regexp.MustCompile(`https?://[^/]+`)
+	cleanedBody := re.ReplaceAllString(responseBody, "")
+	is.Equal(cleanedBody, expectedAirQualityByIDLinksOutput)
+}
+
+const expectedAirQualityByIDOutput string = `{"data":{"id":"aq1","location":{"type":"Point","coordinates":[17.1,62.1]},"dateObserved":{"@type":"DateTime","@value":"2022-10-21T13:10:00Z"},"pollutants":[{"name":"Temperature","values":[{"value":12.6,"observedAt":"2022-10-20T13:10:00Z"}]}]},"links":{"self":"/aq1"}}`
+
+const expectedAirQualityByIDLinksOutput string = `{"data":{"id":"aq1","location":{"type":"Point","coordinates":[17.1,62.1]},"dateObserved":{"@type":"DateTime","@value":"2022-10-21T13:10:00Z"},"pollutants":[{"name":"Temperature","values":[{"value":12.6,"observedAt":"2022-10-20T13:10:00Z"}]}]},"links":{"next":"/aq1?from=2022-10-20T13%3A10%3A00Z&to=2022-10-22T13%3A10%3A00Z","self":"/aq1?from=2022-10-19T13%3A10%3A00Z&to=2022-10-22T13%3A10%3A00Z"}}`
 
 func defaultAirQualityMock() *services.AirQualityServiceMock {
 	mock := &services.AirQualityServiceMock{
@@ -65,8 +85,14 @@ func defaultAirQualityMock() *services.AirQualityServiceMock {
 				return nil, fmt.Errorf("no such air quality")
 			}
 		},
-		GetByIDWithTimespanFunc: func(ctx context.Context, id string, from, to time.Time) (*domain.AirQualityDetails, error) {
-			return nil, nil
+		GetByIDWithTimespanFunc: func(ctx context.Context, id string, from, to time.Time) (*domain.AirQualityDetails, *services.NextTimespan, error) {
+			aq, ok := aqDetails[id]
+			nextFrom := from.Add(time.Hour * 24)
+			if ok {
+				return &aq, &services.NextTimespan{From: &nextFrom, To: &to}, nil
+			}
+
+			return nil, nil, fmt.Errorf("no such air quality")
 		},
 	}
 

--- a/internal/pkg/presentation/handlers/airquality_test.go
+++ b/internal/pkg/presentation/handlers/airquality_test.go
@@ -85,11 +85,11 @@ func defaultAirQualityMock() *services.AirQualityServiceMock {
 				return nil, fmt.Errorf("no such air quality")
 			}
 		},
-		GetByIDWithTimespanFunc: func(ctx context.Context, id string, from, to time.Time) (*domain.AirQualityDetails, *services.NextTimespan, error) {
+		GetByIDWithTimespanFunc: func(ctx context.Context, id string, from, to time.Time) (*domain.AirQualityDetails, *services.Timespan, error) {
 			aq, ok := aqDetails[id]
 			nextFrom := from.Add(time.Hour * 24)
 			if ok {
-				return &aq, &services.NextTimespan{From: &nextFrom, To: &to}, nil
+				return &aq, &services.Timespan{From: nextFrom, To: to}, nil
 			}
 
 			return nil, nil, fmt.Errorf("no such air quality")

--- a/internal/pkg/presentation/handlers/webutil/webutil.go
+++ b/internal/pkg/presentation/handlers/webutil/webutil.go
@@ -1,0 +1,65 @@
+package webutil
+
+import (
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+)
+
+// BuildPublicURL reconstructs the public-facing URL using forwarded headers.
+// Works behind WSO2 API Gateway, Nginx, Envoy, API Gateway, Cloudflare, etc.
+func BuildPublicURL(r *http.Request) *url.URL {
+	u := *r.URL // shallow copy keeps Path and RawQuery
+
+	// ---- Scheme ----
+	scheme := r.Header.Get("X-Forwarded-Proto")
+	if scheme == "" {
+		// Try RFC 7239 Forwarded: proto=https; host=...
+		if f := r.Header.Get("Forwarded"); f != "" {
+			lower := strings.ToLower(f)
+			if strings.Contains(lower, "proto=https") {
+				scheme = "https"
+			} else if strings.Contains(lower, "proto=http") {
+				scheme = "http"
+			}
+		}
+	}
+	if scheme == "" {
+		if r.TLS != nil {
+			scheme = "https"
+		} else {
+			scheme = "http"
+		}
+	}
+
+	// ---- Host ----
+	host := r.Header.Get("X-Forwarded-Host")
+	if host == "" {
+		// Try RFC 7239 Forwarded header
+		if f := r.Header.Get("Forwarded"); f != "" {
+			for _, part := range strings.Split(f, ";") {
+				kv := strings.SplitN(strings.TrimSpace(part), "=", 2)
+				if len(kv) == 2 && strings.ToLower(kv[0]) == "host" {
+					host = strings.Trim(kv[1], "\"")
+					break
+				}
+			}
+		}
+	}
+	if host == "" {
+		host = r.Host
+	}
+
+	// ---- Prefix (optional) ----
+	prefix := r.Header.Get("X-Forwarded-Prefix")
+	if prefix != "" {
+		prefix = "/" + strings.Trim(prefix, "/")
+		u.Path = path.Join(prefix, u.Path)
+	}
+
+	u.Scheme = scheme
+	u.Host = host
+
+	return &u
+}


### PR DESCRIPTION
- Return pagination links (self, next) in API responses
- Document timeAt/endTimeAt query parameters and links object in OpenAPI spec.  
- Deprecated from/to query parameters
- Update tests to verify pagination link generation